### PR TITLE
Remove duplicate entry in cookbook freekarma check, add 4 new entries

### DIFF
--- a/docs/subreddit-configuration/cookbook/freekarma.yaml
+++ b/docs/subreddit-configuration/cookbook/freekarma.yaml
@@ -26,7 +26,10 @@
                   - upvote
                   - promote
                   - shamelessplug
-                  - upvote
+                  - FreeKarma4All
+                  - Karma4Free
+                  - Karma4KarmaforFree
+                  - karma4karmafree
                   - FreeUpVotes
                   - GiveMeKarma
                   - nsfwkarma


### PR DESCRIPTION
Title explains it, I found 4 more subs on a profile who's activity triggered the check to begin with. 